### PR TITLE
Use defaults where possible

### DIFF
--- a/templates/values.yaml
+++ b/templates/values.yaml
@@ -1,9 +1,9 @@
 #@data/values
 ---
-  system_domain: {{ .Values._domain | quote  }}
+  system_domain: {{ .Values.domain | quote  }}
   app_domains:
   #@overlay/append
-  - {{ .Values._domain | quote }}
+  - {{ .Values.domain | quote }}
   cf_admin_password: {{ .Values.cf_admin_password.password | quote }}
   
   cf_blobstore:

--- a/templates/values.yaml
+++ b/templates/values.yaml
@@ -1,9 +1,9 @@
 #@data/values
 ---
-  system_domain: {{ .Values.domain | quote  }}
+  system_domain: {{ .Values._domain | quote  }}
   app_domains:
   #@overlay/append
-  - {{ .Values.domain | quote }}
+  - {{ .Values._domain | quote }}
   cf_admin_password: {{ .Values.cf_admin_password.password | quote }}
   
   cf_blobstore:
@@ -82,10 +82,11 @@
     tls:
       crt: *crt
       key: *key
-  
+
+{{ if .Values.docker_registry }}
   app_registry:
     hostname: {{  regexReplaceAll "/.*$" .Values.docker_registry.repository ""}}
     repository: {{  .Values.docker_registry.repository | quote }}
     username: {{  .Values.docker_registry.username | quote }}
     password: {{  .Values.docker_registry.password | quote }}
-          
+{{ end }}          


### PR DESCRIPTION
* Domain is read from kubenetes host if no domain is passed in the constructor
* If no docker_registry is given don't configure app_registry
* Always use kapp to install this chart

With this settings it's possible to install a working cf without specifying a parameter